### PR TITLE
Update PKGCreatorUniversal.swift

### DIFF
--- a/PhatPKG/PKGCreatorUniversal.swift
+++ b/PhatPKG/PKGCreatorUniversal.swift
@@ -199,10 +199,18 @@ class PKGCreatorUniversal {
         let infoPlistPath = "\(appPath)/Contents/Info.plist"
         guard let plistData = NSDictionary(contentsOfFile: infoPlistPath),
               let appID = plistData["CFBundleIdentifier"] as? String,
-              let appVersion = plistData["CFBundleShortVersionString"] as? String,
-              let appName = plistData["CFBundleName"] as? String else {
+              let appVersion = plistData["CFBundleShortVersionString"] as? String else {
             return nil
         }
+        
+        let appName: String
+        if let bundleName = plistData["CFBundleName"] as? String {
+            appName = bundleName
+        } else {
+            let pathComponent = (appPath as NSString).lastPathComponent
+            appName = (pathComponent as NSString).deletingPathExtension
+        }
+        
         return (appName, appID, appVersion)
     }
 


### PR DESCRIPTION
Use path component for app name if CFBundleName is not present.